### PR TITLE
updated metadata endpoints to work with API explorer

### DIFF
--- a/BAR_ePlant/metadata.yml
+++ b/BAR_ePlant/metadata.yml
@@ -1,9 +1,10 @@
 ---
+
 name: eplant_service
 description: Multi-point pass-through adaptor for BAR ePlant web services.
 version: 0.1
 icon: BAR.png
-tag:
+tags:
     - 'eplant'
     - 'arabidopsis'
     - 'expression'
@@ -20,29 +21,32 @@ whitelist:
     - bar.utoronto.ca
 
 endpoints:
-    /speciesinfo.cgi:
-        description: Return a JSON list of species
-    /chromosomeinfo.cgi:
-        description: Return chromosome information given a species
-        parameters:
-            - name: species
-              description: Species Name
-              type: string
-              required: true
-              default: Arabidopsis_thaliana
-    /querygene.cgi:
-        description: Query a gene
-        parameters:
-            - name: species
-              description: Species Name
-              type: string
-              required: true
-              default: Arabidopsis_thaliana
-            - name: term
-              description: Gene name such as ABI3
-              type: string
-              required: true
-              default: abi3
+    /access/speciesinfo.cgi:
+        get:
+            description: Return a JSON list of species
+    /access/chromosomeinfo.cgi:
+        get:
+            description: Return chromosome information given a species
+            parameters:
+                - name: species
+                  description: Species Name
+                  type: string
+                  required: true
+                  default: Arabidopsis_thaliana
+    /access/querygene.cgi:
+        get:
+            description: Query a gene
+            parameters:
+                - name: species
+                  description: Species Name
+                  type: string
+                  required: true
+                  default: Arabidopsis_thaliana
+                - name: term
+                  description: Gene name such as ABI3
+                  type: string
+                  required: true
+                  default: abi3
 
 sources:
     - title: BAR ePlant
@@ -52,4 +56,4 @@ sources:
       sponsor_uri: http://www.utoronto.ca/
       provider_name: Nicholas Provart
       provider_email: nicholas.provart@utoronto.ca
-      uri: http://bar.utoronto.ca/eplant 
+      uri: http://bar.utoronto.ca/eplant


### PR DESCRIPTION
A minor change which allows the endpoints to be tested in the API explorer on Araport (https://www.araport.org/api-explorer).
